### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    reviewers:
+      - "aguilaair"
+      - "leoafarias"
+    schedule:
+      interval: "daily"
+      time: "09:00"


### PR DESCRIPTION
Dependabot for Pub is now available in beta. This PR adds the required configuration to use it.

https://github.blog/changelog/2022-04-05-pub-beta-support-for-dependabot-version-updates/