### PR TITLE
Fix more than one ScrollController attached

### DIFF
--- a/lib/src/modules/projects/projects.screen.dart
+++ b/lib/src/modules/projects/projects.screen.dart
@@ -1,5 +1,4 @@
 import 'package:file_selector/file_selector.dart' as selector;
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/lib/src/modules/projects/projects.screen.dart
+++ b/lib/src/modules/projects/projects.screen.dart
@@ -98,7 +98,7 @@ class ProjectsScreen extends HookWidget {
           : Padding(
               padding: const EdgeInsets.only(left: 10),
               child: SingleChildScrollView(
-                controller: ScrollController(initialScrollOffset: 60),
+                controller: ScrollController(),
                 child: Padding(
                   padding: const EdgeInsets.only(top: 60),
                   child: ResponsiveGridList(

--- a/lib/src/modules/projects/projects.screen.dart
+++ b/lib/src/modules/projects/projects.screen.dart
@@ -96,22 +96,27 @@ class ProjectsScreen extends HookWidget {
       ],
       child: projects.isEmpty
           ? const EmptyProjects()
-          : CupertinoScrollbar(
-              child: Padding(
-                padding: const EdgeInsets.only(left: 10),
-                child: ResponsiveGridList(
-                    desiredItemWidth: 290,
-                    minSpacing: 0,
-                    children: filteredProjects.value.map((project) {
-                      return Padding(
-                        padding: const EdgeInsets.only(top: 10, right: 10),
-                        child: ProjectListItem(
-                          project,
-                          versionSelect: true,
-                          key: Key(project.projectDir.path),
-                        ),
-                      );
-                    }).toList()),
+          : Padding(
+              padding: const EdgeInsets.only(left: 10),
+              child: SingleChildScrollView(
+                controller: ScrollController(initialScrollOffset: 60),
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 60),
+                  child: ResponsiveGridList(
+                      desiredItemWidth: 290,
+                      scroll: false,
+                      minSpacing: 0,
+                      children: filteredProjects.value.map((project) {
+                        return Padding(
+                          padding: const EdgeInsets.only(top: 10, right: 10),
+                          child: ProjectListItem(
+                            project,
+                            versionSelect: true,
+                            key: Key(project.projectDir.path),
+                          ),
+                        );
+                      }).toList()),
+                ),
               ),
             ),
     );


### PR DESCRIPTION
@leoafarias is there a better way to do this?

The issue is that the scrollbar does not work on projects because it is being attached by both SkScreen to handle the extension behind the body and the gridview. This PR resolves it but in turn creates an issue whereby items are no longer dynamically generated so if there are many projects performance will be subpar.