### PR TITLE
hotfix: frame errors on MacOS Ventura

### DIFF
--- a/macos/Podfile
+++ b/macos/Podfile
@@ -36,5 +36,8 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_macos_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '10.14'
+    end
   end
 end

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,33 +1,23 @@
 import Cocoa
 import FlutterMacOS
+import flutter_acrylic
 import bitsdojo_window_macos
 
 class MainFlutterWindow: BitsdojoWindow {
   override func bitsdojo_window_configure() -> UInt {
     return BDW_CUSTOM_FRAME | BDW_HIDE_ON_STARTUP
   }
+  
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
     let windowFrame = self.frame
-    self.contentViewController = flutterViewController
+    let blurryContainerViewController = BlurryContainerViewController() // new
+    self.contentViewController = blurryContainerViewController // new
     self.setFrame(windowFrame, display: true)
-    RegisterGeneratedPlugins(registry: flutterViewController)
     
-    // Adding a NSVisualEffectView to act as a translucent background
-    let contentView = contentViewController!.view;
-    let superView = contentView.superview!;
-
-    let blurView = NSVisualEffectView(frame: superView.bounds)
-    blurView.autoresizingMask = [.width, .height]
-    blurView.blendingMode = NSVisualEffectView.BlendingMode.behindWindow
-
-    // Pick the correct material for the task
-    blurView.material = NSVisualEffectView.Material.underWindowBackground
-
-    // Replace the contentView and the background view
-    superView.replaceSubview(contentView, with: blurView)
-    blurView.addSubview(contentView)
-
+    /* Initialize the flutter_acrylic plugin */
+    MainFlutterWindowManipulator.start(mainFlutterWindow: self) // new
+    
+    RegisterGeneratedPlugins(registry: blurryContainerViewController.flutterViewController) // new
     super.awakeFromNib()
   }
 }


### PR DESCRIPTION
# Related Issues

- https://github.com/fluttertools/sidekick/issues/255

# Context

After users start sidekick on MacOS Ventura (>= 13.*), the issues in the above related issue are appearing.

# What this PR solves

- Fixes `flutter_acrylic` and `bitsdojo_window` native code in `MainFlutterWindow.swift`
- False calculation due to deprecated native code in `MainFlutterWindow.swift`
- Dependencies depending on MacOS Deployment Target < `10.13.*` are overriden now to `10.14`