### PR TITLE
Fix linux appimage build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,11 +40,6 @@ jobs:
         with:
           filename: linux-dev.zip
 
-      - name: Build AppImage
-        uses: AppImageCrafters/build-appimage@master
-        with:
-          recipe: "AppImageBuilder.yml"
-
       - name: Upload Build AppImage
         uses: actions/upload-artifact@v2.3.1
         with:
@@ -103,7 +98,7 @@ jobs:
           channel: 'stable'
 
       - name: Set Up XCode
-        uses: devbotsxyz/xcode-select@v1.1.0
+        uses: BoundfoxStudios/action-xcode-select@v1
 
       - name: Enable desktop
         run: flutter config --enable-macos-desktop

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,10 +45,10 @@ jobs:
           name: sidekick-linux-dev.zip
           path: linux-dev.zip
 
-      - name: Install FUSE (appbuilder dep)
+      - name: Install appbuilder deps
         run: |
           sudo add-apt-repository universe
-          sudo apt install libfuse2
+          sudo apt install libfuse2 libgtk-3-0
 
       - name: Install appimagebuilder
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,10 +59,6 @@ jobs:
         run: |
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
-
-      - name: Set setuptools to version ^65
-        run: |
-          sudo pip3 install --upgrade setuptools=65
       
       - name: Install appimage-builder
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,6 +65,10 @@ jobs:
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
 
+      - name: Set setuptools to version ^65
+        run: |
+          sudo pip3 install setuptools=65
+      
       - name: Install appimage-builder
         run: |
           sudo pip3 install appimage-builder

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,16 +60,11 @@ jobs:
         run: |
           appimage-builder --recipe AppImageBuilder.yml
 
-      - name: Upload AppImage to release
-        uses: svenstaro/upload-release-action@2.2.1
+      - name: Upload Build AppImage
+        uses: actions/upload-artifact@v2.3.1
         with:
-          # GitHub token.
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          # Local file to upload.
-          file: Sidekick-latest-x86_64.AppImage
-          asset_name: sidekick-linux-dev.AppImage
-          # Tag to use as a release.
-          tag: ${{ github.ref }}
+          name: sidekick-linux-dev.AppImage
+          path: Sidekick-latest-x86_64.AppImage
 
   build-macos:
     name: "Build MacOS"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Install Linux build tools
         run: sudo apt-get update && sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev squashfs-tools
@@ -34,35 +34,22 @@ jobs:
       - name: Flutter build app
         run: flutter build linux
 
-
       - name: Compress artifacts
         uses: TheDoctor0/zip-release@0.6.1
         with:
           filename: linux-dev.zip
 
-      - name: Upload Build AppImage
-        uses: actions/upload-artifact@v2.3.1
-        with:
-          name: sidekick-linux-dev.AppImage
-          path: Sidekick-latest-x86_64.AppImage
-      
       - name: Upload Build Zip
         uses: actions/upload-artifact@v2.3.1
         with:
           name: sidekick-linux-dev.zip
           path: linux-dev.zip
 
-      - name: Install appimage-builder deps
-        run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
-
-      - name: Install appimagetool
+      - name: Install appimagebuilder
         run: |
-          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
-          sudo chmod +x /usr/local/bin/appimagetool
-      
-      - name: Install appimage-builder
-        run: |
-          sudo pip3 install appimage-builder
+          wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage
+          chmod +x appimage-builder-x86_64.AppImage
+          sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
 
       - name: Build AppImage
         run: |
@@ -75,10 +62,10 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           # Local file to upload.
           file: Sidekick-latest-x86_64.AppImage
-          asset_name: sidekick-linux-${{ github.event.release.tag_name }}.AppImage
+          asset_name: sidekick-linux-dev.AppImage
           # Tag to use as a release.
           tag: ${{ github.ref }}
-      
+
   build-macos:
     name: "Build MacOS"
     runs-on: macos-latest
@@ -91,7 +78,7 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Set Up XCode
         uses: BoundfoxStudios/action-xcode-select@v1
@@ -123,13 +110,12 @@ jobs:
         with:
           name: sidekick-macos-dev.dmg
           path: build/macos/Build/Products/Release/Sidekick.dmg
-      
+
       - name: Upload Build Zip
         uses: actions/upload-artifact@v2.3.1
         with:
           name: sidekick-macos-dev.zip
           path: macos-dev.zip
-
 
   build-windows:
     name: "Build Windows"
@@ -143,7 +129,7 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Enable desktop
         run: flutter config --enable-windows-desktop
@@ -173,7 +159,7 @@ jobs:
               store: false
           write-mode: append
 
-      - name: Write MS Store 
+      - name: Write MS Store
         uses: DamianReeves/write-file-action@v1.0
         with:
           path: lib/modifiers.dart
@@ -196,7 +182,7 @@ jobs:
         with:
           name: sidekick-windows-dev.msix
           path: build/windows/Runner/release/sidekick.msix
-      
+
       - name: Upload Build Zip
         uses: actions/upload-artifact@v2.3.1
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,11 @@ jobs:
           name: sidekick-linux-dev.zip
           path: linux-dev.zip
 
+      - name: Install FUSE (appbuilder dep)
+        run: |
+          sudo add-apt-repository universe
+          sudo apt install libfuse2
+
       - name: Install appimagebuilder
         run: |
           wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,6 +56,33 @@ jobs:
         with:
           name: sidekick-linux-dev.zip
           path: linux-dev.zip
+
+      - name: Install appimage-builder deps
+        run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
+
+      - name: Install appimagetool
+        run: |
+          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+          sudo chmod +x /usr/local/bin/appimagetool
+
+      - name: Install appimage-builder
+        run: |
+          sudo pip3 install appimage-builder
+
+      - name: Build AppImage
+        run: |
+          appimage-builder --recipe AppImageBuilder.yml
+
+      - name: Upload AppImage to release
+        uses: svenstaro/upload-release-action@2.2.1
+        with:
+          # GitHub token.
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          # Local file to upload.
+          file: Sidekick-latest-x86_64.AppImage
+          asset_name: sidekick-linux-${{ github.event.release.tag_name }}.AppImage
+          # Tag to use as a release.
+          tag: ${{ github.ref }}
       
   build-macos:
     name: "Build MacOS"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Set setuptools to version ^65
         run: |
-          sudo pip3 install setuptools=65
+          sudo pip3 install --upgrade setuptools=65
       
       - name: Install appimage-builder
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Set setuptools to version ^65
         run: |
-          sudo pip3 install setuptools=65
+          sudo pip3 install --upgrade setuptools=65
 
       - name: Install appimage-builder
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,6 +53,10 @@ jobs:
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
 
+      - name: Set setuptools to version ^65
+        run: |
+          sudo pip3 install setuptools=65
+
       - name: Install appimage-builder
         run: |
           sudo pip3 install appimage-builder

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,10 +45,10 @@ jobs:
           name: sidekick-linux-dev.zip
           path: linux-dev.zip
 
-      - name: Install FUSE (appbuilder dep)
+      - name: Install appbuilder deps
         run: |
           sudo add-apt-repository universe
-          sudo apt install libfuse2
+          sudo apt install libfuse2 libgtk-3-0
 
       - name: Install appimagebuilder
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,16 +60,11 @@ jobs:
         run: |
           appimage-builder --recipe AppImageBuilder.yml
 
-      - name: Upload AppImage to release
-        uses: svenstaro/upload-release-action@2.2.1
+      - name: Upload Build AppImage
+        uses: actions/upload-artifact@v2.3.1
         with:
-          # GitHub token.
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          # Local file to upload.
-          file: Sidekick-latest-x86_64.AppImage
-          asset_name: sidekick-linux-dev.AppImage
-          # Tag to use as a release.
-          tag: ${{ github.ref }}
+          name: sidekick-linux-dev.AppImage
+          path: Sidekick-latest-x86_64.AppImage
 
   build-macos:
     name: "Build MacOS"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,9 +53,17 @@ jobs:
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
 
-      - name: Set setuptools to version 65.7.0
+      - name: Install appimage-builder deps
+        run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
+
+      - name: Install appimagetool
         run: |
-          sudo pip3 install --upgrade setuptools==65.7.0
+          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+          sudo chmod +x /usr/local/bin/appimagetool
+
+      - name: Set setuptools to version ^65
+        run: |
+          sudo pip3 install --upgrade setuptools=65
 
       - name: Install appimage-builder
         run: |
@@ -92,7 +100,7 @@ jobs:
           channel: 'stable'
 
       - name: Set Up XCode
-        uses: devbotsxyz/xcode-select@v1.1.0
+        uses: BoundfoxStudios/action-xcode-select@v1
 
       - name: Enable desktop
         run: flutter config --enable-macos-desktop

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,6 +45,11 @@ jobs:
           name: sidekick-linux-dev.zip
           path: linux-dev.zip
 
+      - name: Install FUSE (appbuilder dep)
+        run: |
+          sudo add-apt-repository universe
+          sudo apt install libfuse2
+
       - name: Install appimagebuilder
         run: |
           wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,9 +61,6 @@ jobs:
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
 
-      - name: Set setuptools to version ^65
-        run: |
-          sudo pip3 install --upgrade setuptools=65
 
       - name: Install appimage-builder
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,6 +44,34 @@ jobs:
         with:
           name: sidekick-linux-dev.zip
           path: linux-dev.zip
+
+      - name: Install appimage-builder deps
+        run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
+
+      - name: Install appimagetool
+        run: |
+          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+          sudo chmod +x /usr/local/bin/appimagetool
+
+      - name: Install appimage-builder
+        run: |
+          sudo pip3 install appimage-builder
+
+      - name: Build AppImage
+        run: |
+          appimage-builder --recipe AppImageBuilder.yml
+
+      - name: Upload AppImage to release
+        uses: svenstaro/upload-release-action@2.2.1
+        with:
+          # GitHub token.
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          # Local file to upload.
+          file: Sidekick-latest-x86_64.AppImage
+          asset_name: sidekick-linux-${{ github.event.release.tag_name }}.AppImage
+          # Tag to use as a release.
+          tag: ${{ github.ref }}
+
       
   build-macos:
     name: "Build MacOS"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,9 +53,9 @@ jobs:
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
 
-      - name: Set setuptools to version ^65
+      - name: Set setuptools to version 65.7.0
         run: |
-          sudo pip3 install --upgrade setuptools=65
+          sudo pip3 install --upgrade setuptools==65.7.0
 
       - name: Install appimage-builder
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Install Linux build tools
         run: sudo apt-get update && sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev squashfs-tools
@@ -38,33 +38,18 @@ jobs:
         uses: TheDoctor0/zip-release@0.6.1
         with:
           filename: linux-dev.zip
-      
+
       - name: Upload Build Zip
         uses: actions/upload-artifact@v2.3.1
         with:
           name: sidekick-linux-dev.zip
           path: linux-dev.zip
 
-      - name: Install appimage-builder deps
-        run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
-
-      - name: Install appimagetool
+      - name: Install appimagebuilder
         run: |
-          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
-          sudo chmod +x /usr/local/bin/appimagetool
-
-      - name: Install appimage-builder deps
-        run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
-
-      - name: Install appimagetool
-        run: |
-          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
-          sudo chmod +x /usr/local/bin/appimagetool
-
-
-      - name: Install appimage-builder
-        run: |
-          sudo pip3 install appimage-builder
+          wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage
+          chmod +x appimage-builder-x86_64.AppImage
+          sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
 
       - name: Build AppImage
         run: |
@@ -77,11 +62,10 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           # Local file to upload.
           file: Sidekick-latest-x86_64.AppImage
-          asset_name: sidekick-linux-${{ github.event.release.tag_name }}.AppImage
+          asset_name: sidekick-linux-dev.AppImage
           # Tag to use as a release.
           tag: ${{ github.ref }}
 
-      
   build-macos:
     name: "Build MacOS"
     runs-on: macos-latest
@@ -94,7 +78,7 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Set Up XCode
         uses: BoundfoxStudios/action-xcode-select@v1
@@ -126,13 +110,12 @@ jobs:
         with:
           name: sidekick-macos-dev.dmg
           path: build/macos/Build/Products/Release/Sidekick.dmg
-      
+
       - name: Upload Build Zip
         uses: actions/upload-artifact@v2.3.1
         with:
           name: sidekick-macos-dev.zip
           path: macos-dev.zip
-
 
   build-windows:
     name: "Build Windows"
@@ -146,7 +129,7 @@ jobs:
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2.6.1
         with:
-          channel: 'stable'
+          channel: "stable"
 
       - name: Enable desktop
         run: flutter config --enable-windows-desktop
@@ -157,7 +140,7 @@ jobs:
       - name: Analyze
         run: flutter analyze
 
-      - name: Write MS Store 
+      - name: Write MS Store
         uses: DamianReeves/write-file-action@v1.0
         with:
           path: lib/modifiers.dart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,10 @@ jobs:
           # Tag to use as a release.
           tag: ${{ github.ref }}
 
-      - name: Install FUSE (appbuilder dep)
+      - name: Install appbuilder deps
         run: |
           sudo add-apt-repository universe
-          sudo apt install libfuse2
+          sudo apt install libfuse2 libgtk-3-0
 
       - name: Install appimagebuilder
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Set setuptools to version ^65
         run: |
-          sudo pip3 install setuptools=65
+          sudo pip3 install --upgrade setuptools=65
 
       - name: Install appimage-builder
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,21 +81,32 @@ jobs:
           # Tag to use as a release.
           tag: ${{ github.ref }}
 
-      #- name: Build AppImage
-      #  uses: AppImageCrafters/build-appimage@master
-      #  with:
-      #    recipe: "AppImageBuilder.yml"
+      - name: Install appimage-builder deps
+        run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
 
-      #- name: Upload AppImage to release
-      #  uses: svenstaro/upload-release-action@2.2.1
-      #  with:
-      #    # GitHub token.
-      #    repo_token: ${{ secrets.GITHUB_TOKEN }}
-      #    # Local file to upload.
-      #    file: Sidekick-latest-x86_64.AppImage
-      #    asset_name: sidekick-linux-${{ github.event.release.tag_name }}.AppImage
+      - name: Install appimagetool
+        run: |
+          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+          sudo chmod +x /usr/local/bin/appimagetool
+
+      - name: Install appimage-builder
+        run: |
+          sudo pip3 install appimage-builder
+
+      - name: Build AppImage
+        run: |
+          appimage-builder --recipe AppImageBuilder.yml
+
+      - name: Upload AppImage to release
+        uses: svenstaro/upload-release-action@2.2.1
+        with:
+          # GitHub token.
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          # Local file to upload.
+          file: Sidekick-latest-x86_64.AppImage
+          asset_name: sidekick-linux-${{ github.event.release.tag_name }}.AppImage
           # Tag to use as a release.
-      #    tag: ${{ github.ref }}
+          tag: ${{ github.ref }}
 
   build-macos:
     name: "Build MacOS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,10 @@ jobs:
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
 
+      - name: Set setuptools to version ^65
+        run: |
+          sudo pip3 install setuptools=65
+
       - name: Install appimage-builder
         run: |
           sudo pip3 install appimage-builder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,17 +81,11 @@ jobs:
           # Tag to use as a release.
           tag: ${{ github.ref }}
 
-      - name: Install appimage-builder deps
-        run: sudo apt install -y binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync
-
-      - name: Install appimagetool
+      - name: Install appimagebuilder
         run: |
-          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
-          sudo chmod +x /usr/local/bin/appimagetool
-
-      - name: Install appimage-builder
-        run: |
-          sudo pip3 install appimage-builder
+          wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage
+          chmod +x appimage-builder-x86_64.AppImage
+          sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
 
       - name: Build AppImage
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,11 @@ jobs:
           # Tag to use as a release.
           tag: ${{ github.ref }}
 
+      - name: Install FUSE (appbuilder dep)
+        run: |
+          sudo add-apt-repository universe
+          sudo apt install libfuse2
+
       - name: Install appimagebuilder
         run: |
           wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           channel: "stable"
 
       - name: Set Up XCode
-        uses: devbotsxyz/xcode-select@v1.1.0
+        uses: BoundfoxStudios/action-xcode-select@v1
 
       - name: Install create-dmg
         run: brew install create-dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,6 @@ jobs:
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
 
-      - name: Set setuptools to version ^65
-        run: |
-          sudo pip3 install --upgrade setuptools=65
-
       - name: Install appimage-builder
         run: |
           sudo pip3 install appimage-builder

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -40,22 +40,6 @@ AppDir:
     - usr/share/doc/*/changelog.*
     - usr/share/doc/*/NEWS.*
     - usr/share/doc/*/TODO.*
-  test:
-    fedora-30:
-      image: appimagecrafters/tests-env:fedora-30
-      command: ./AppRun
-    debian-stable:
-      image: appimagecrafters/tests-env:debian-stable
-      command: ./AppRun
-    archlinux-latest:
-      image: appimagecrafters/tests-env:archlinux-latest
-      command: ./AppRun
-    centos-7:
-      image: appimagecrafters/tests-env:centos-7
-      command: ./AppRun
-    ubuntu-xenial:
-      image: appimagecrafters/tests-env:ubuntu-xenial
-      command: ./AppRun
 AppImage:
   arch: x86_64
   update-information: guess

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,9 +1,10 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
 version: 1
 script:
-  - rm -rf ./AppDir || true
-  - cp -r ./build/linux/x64/release/bundle ./AppDir
-  - mkdir -p ./AppDir/usr/share/icons/hicolor/64x64/apps/
-  - cp ./snap/gui/Sidekick.png ./AppDir/usr/share/icons/hicolor/64x64/apps/
+ - rm -rf ./AppDir || true
+ - cp -r ./build/linux/x64/release/bundle ./AppDir
+ - mkdir -p ./AppDir/usr/share/icons/hicolor/64x64/apps/
+ - cp ./snap/guis/Sidekick.png ./AppDir/usr/share/icons/hicolor/64x64/apps/
 AppDir:
   path: ./AppDir
   app_info:
@@ -14,49 +15,47 @@ AppDir:
     exec: Sidekick
     exec_args: $@
   apt:
-    arch: amd64
+    arch:
+    - amd64
     allow_unauthenticated: true
     sources:
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammyy-backports main restricted universe multiverse
-      - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
+    - sourceline: deb http://es.archive.ubuntu.com/ubuntu/ jammy main restricted
+    - sourceline: deb http://es.archive.ubuntu.com/ubuntu/ jammy-updates main restricted
+    - sourceline: deb http://es.archive.ubuntu.com/ubuntu/ jammy universe
+    - sourceline: deb http://es.archive.ubuntu.com/ubuntu/ jammy-updates universe
+    - sourceline: deb http://es.archive.ubuntu.com/ubuntu/ jammy multiverse
+    - sourceline: deb http://es.archive.ubuntu.com/ubuntu/ jammy-updates multiverse
+    - sourceline: deb http://es.archive.ubuntu.com/ubuntu/ jammy-backports main restricted
+        universe multiverse
+    - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security main restricted
+    - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security universe
+    - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security multiverse
     include:
-      - libgtk-3-0
-    exclude:
-      - humanity-icon-theme
-      - hicolor-icon-theme
-      - adwaita-icon-theme
-      - ubuntu-mono
+    - libc6:amd64
   files:
+    include: []
     exclude:
-      - usr/share/man
-      - usr/share/doc/*/README.*
-      - usr/share/doc/*/changelog.*
-      - usr/share/doc/*/NEWS.*
-      - usr/share/doc/*/TODO.*
+    - usr/share/man
+    - usr/share/doc/*/README.*
+    - usr/share/doc/*/changelog.*
+    - usr/share/doc/*/NEWS.*
+    - usr/share/doc/*/TODO.*
   test:
-    fedora:
+    fedora-30:
       image: appimagecrafters/tests-env:fedora-30
       command: ./AppRun
-      use_host_x: true
-    debian:
+    debian-stable:
       image: appimagecrafters/tests-env:debian-stable
       command: ./AppRun
-      use_host_x: true
-    arch:
+    archlinux-latest:
       image: appimagecrafters/tests-env:archlinux-latest
       command: ./AppRun
-      use_host_x: true
-    centos:
+    centos-7:
       image: appimagecrafters/tests-env:centos-7
       command: ./AppRun
-      use_host_x: true
-    ubuntu:
-      image: appimagecrafters/tests-env:ubuntu-bionic
+    ubuntu-xenial:
+      image: appimagecrafters/tests-env:ubuntu-xenial
       command: ./AppRun
-      use_host_x: true
 AppImage:
   arch: x86_64
   update-information: guess
-  sign-key: None

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -17,10 +17,10 @@ AppDir:
     arch: amd64
     allow_unauthenticated: true
     sources:
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe multiverse
-      - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
-      - sourceline: deb http://security.ubuntu.com/ubuntu bionic-security main restricted universe multiverse
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse
+      - sourceline: deb http://archive.ubuntu.com/ubuntu/ jammyy-backports main restricted universe multiverse
+      - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
     include:
       - libgtk-3-0
     exclude:

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,10 +1,10 @@
 # appimage-builder recipe see https://appimage-builder.readthedocs.io for details
 version: 1
 script:
- - rm -rf ./AppDir || true
- - cp -r ./build/linux/x64/release/bundle ./AppDir
- - mkdir -p ./AppDir/usr/share/icons/hicolor/64x64/apps/
- - cp ./snap/guis/Sidekick.png ./AppDir/usr/share/icons/hicolor/64x64/apps/
+  - rm -rf ./AppDir || true
+  - cp -r ./build/linux/x64/release/bundle ./AppDir
+  - mkdir -p ./AppDir/usr/share/icons/hicolor/64x64/apps/
+  - cp ./snap/gui/Sidekick.png ./AppDir/usr/share/icons/hicolor/64x64/apps/
 AppDir:
   path: ./AppDir
   app_info:


### PR DESCRIPTION
The action we were using has been broken for over a year now. This PR switches to generating that app image manually to get CI up to par with the user systems. 

Fixes #223