### PR TITLE
chore: Remove dev releases

### DIFF
--- a/lib/src/modules/common/constants.dart
+++ b/lib/src/modules/common/constants.dart
@@ -17,7 +17,7 @@ const kNavigationWidth = 65.0;
 const kNavigationWidthExtended = 180.0;
 
 /// Channels without master
-const kReleaseChannels = ['stable', 'beta', 'dev'];
+const kReleaseChannels = ['stable', 'beta'];
 
 /// Master channel
 const kMasterChannel = 'master';
@@ -35,6 +35,5 @@ const kFlutterTagsUrl = 'https://github.com/flutter/flutter/releases/tag/';
 Map<String, String> channelDescriptions(BuildContext context) => {
       'stable': context.i18n('modules:common.stableChannelDescription'),
       'beta': context.i18n('modules:common.betaChannelDescription'),
-      'dev': context.i18n('modules:common.devChannelDescription'),
       'master': context.i18n('modules:common.masterChannelDescription'),
     };

--- a/lib/src/modules/releases/releases.provider.dart
+++ b/lib/src/modules/releases/releases.provider.dart
@@ -197,7 +197,6 @@ final getVersionProvider = Provider.family<ReleaseDto?, String?>(
 enum Filter {
   beta,
   stable,
-  dev,
   all,
 }
 
@@ -214,8 +213,6 @@ Filter filterFromName(String name) {
   switch (name) {
     case 'stable':
       return Filter.stable;
-    case 'dev':
-      return Filter.dev;
     case 'beta':
       return Filter.beta;
     case 'all':

--- a/lib/src/modules/search/components/search_results_list.dart
+++ b/lib/src/modules/search/components/search_results_list.dart
@@ -96,22 +96,6 @@ class SearchResultsList extends StatelessWidget {
               ),
             ],
           ),
-          SliverSection(
-            shouldDisplay: results.devReleases.isNotEmpty,
-            slivers: [
-              SliverPersistentHeader(
-                delegate: SliverHeaderDelegate(
-                  title: context.i18n('modules:search.components.devReleases'),
-                  count: results.devReleases.length,
-                ),
-              ),
-              SliverList(
-                delegate: SliverChildBuilderDelegate((context, index) {
-                  return ReleaseListItem(results.devReleases[index]);
-                }, childCount: results.devReleases.length),
-              ),
-            ],
-          ),
         ],
       ),
     );

--- a/lib/src/modules/search/search.provider.dart
+++ b/lib/src/modules/search/search.provider.dart
@@ -40,16 +40,12 @@ class SearchResults {
   /// Beta Releases
   final List<VersionDto> betaReleases;
 
-  /// Dev Releases
-  final List<VersionDto> devReleases;
-
   /// Constructor
   SearchResults({
     this.projects = const [],
     this.channels = const [],
     this.stableReleases = const [],
     this.betaReleases = const [],
-    this.devReleases = const [],
   });
 
   /// No results
@@ -57,8 +53,7 @@ class SearchResults {
     return projects.isEmpty &&
         channels.isEmpty &&
         stableReleases.isEmpty &&
-        betaReleases.isEmpty &&
-        devReleases.isEmpty;
+        betaReleases.isEmpty;
   }
 }
 
@@ -84,7 +79,6 @@ final searchResultsProvider = Provider((ref) {
   final channelResults = <ChannelDto>[];
   final stableReleaseResults = <VersionDto>[];
   final betaReleaseResults = <VersionDto>[];
-  final devReleaseResults = <VersionDto>[];
 
   // We look for multiple terms, make sure result only shows up once
   final uniques = <String, bool>{};
@@ -141,9 +135,6 @@ final searchResultsProvider = Provider((ref) {
           case Channel.beta:
             betaReleaseResults.add(release);
             break;
-          case Channel.dev:
-            devReleaseResults.add(release);
-            break;
           default:
 
             /// TODO: If this logic is removed, it should support passing actual Context
@@ -175,6 +166,5 @@ final searchResultsProvider = Provider((ref) {
     projects: projectResults,
     stableReleases: stableReleaseResults,
     betaReleases: betaReleaseResults,
-    devReleases: devReleaseResults,
   );
 });

--- a/localizations/ar-SA/modules.json
+++ b/localizations/ar-SA/modules.json
@@ -106,7 +106,6 @@
       "channels": "القنوات",
       "stableReleases": "الإصدارات المستقرة",
       "betaReleases": "الإصدارات التجريبية",
-      "devReleases": "الإصدارات التجريبية \"مطورين\"",
       "invalidChanel": "قناة غير صالحة"
     }
   },

--- a/localizations/bn-BD/modules.json
+++ b/localizations/bn-BD/modules.json
@@ -106,7 +106,6 @@
       "channels": "চ্যানেলসমূহ",
       "stableReleases": "স্টেবল রিলিজেস",
       "betaReleases": "বিটা রিলিজেস",
-      "devReleases": "ডেভ রিলিজেস",
       "invalidChanel": "অবৈধ চ্যানেল"
     }
   },

--- a/localizations/de-DE/modules.json
+++ b/localizations/de-DE/modules.json
@@ -106,7 +106,6 @@
       "channels": "Channels",
       "stableReleases": "Stable Releases",
       "betaReleases": "Beta Releases",
-      "devReleases": "Dev Releases",
       "invalidChannel": "Ungültiger Channel"
     }
   },

--- a/localizations/en-GB/modules.json
+++ b/localizations/en-GB/modules.json
@@ -106,7 +106,6 @@
       "channels": "Channels",
       "stableReleases": "Stable Releases",
       "betaReleases": "Beta Releases",
-      "devReleases": "Dev Releases",
       "invalidChanel": "Invalid Channel"
     }
   },

--- a/localizations/en-US/modules.json
+++ b/localizations/en-US/modules.json
@@ -106,7 +106,6 @@
       "channels": "Channels",
       "stableReleases": "Stable Releases",
       "betaReleases": "Beta Releases",
-      "devReleases": "Dev Releases",
       "invalidChanel": "Invalid Channel"
     }
   },

--- a/localizations/es-ES/modules.json
+++ b/localizations/es-ES/modules.json
@@ -106,7 +106,6 @@
       "channels": "Canales",
       "stableReleases": "Vesiones Estables",
       "betaReleases": "Versiones Beta",
-      "devReleases": "Versiones Dev",
       "invalidChanel": "Canal inválido"
     }
   },

--- a/localizations/fr-FR/modules.json
+++ b/localizations/fr-FR/modules.json
@@ -106,7 +106,6 @@
       "channels": "Branches",
       "stableReleases": "Releases stables",
       "betaReleases": "Releases beta",
-      "devReleases": "Releases dev",
       "invalidChanel": "Branche invalide"
     }
   },

--- a/localizations/hi-IN/modules.json
+++ b/localizations/hi-IN/modules.json
@@ -106,7 +106,6 @@
       "channels": "चैनल",
       "stableReleases": "स्टैबल रिलीज",
       "betaReleases": "बीटा रिलीज",
-      "devReleases": "देव रिलीज",
       "invalidChanel": "अमान्य चैनल"
     }
   },

--- a/localizations/id-ID/modules.json
+++ b/localizations/id-ID/modules.json
@@ -106,7 +106,6 @@
       "channels": "Channel",
       "stableReleases": "Rilis Stabil",
       "betaReleases": "Rilis Beta",
-      "devReleases": "Rilis Dev",
       "invalidChanel": "Channel Tidak Valid"
     }
   },

--- a/localizations/it-IT/modules.json
+++ b/localizations/it-IT/modules.json
@@ -106,7 +106,6 @@
       "channels": "Canali",
       "stableReleases": "Stable Releases",
       "betaReleases": "Beta Releases",
-      "devReleases": "Dev Releases",
       "invalidChanel": "Canale non valido"
     }
   },

--- a/localizations/ja-JP/modules.json
+++ b/localizations/ja-JP/modules.json
@@ -106,7 +106,6 @@
       "channels": "チャンネル",
       "stableReleases": "Stableリリース",
       "betaReleases": "Betaリリース",
-      "devReleases": "Devリリース",
       "invalidChanel": "無効なチャンネル"
     }
   },

--- a/localizations/ko-KR/modules.json
+++ b/localizations/ko-KR/modules.json
@@ -106,7 +106,6 @@
       "channels": "채널",
       "stableReleases": "안정 버전",
       "betaReleases": "베타 버전",
-      "devReleases": "개발자 버전",
       "invalidChanel": "유효하지 않은 버전"
     }
   },

--- a/localizations/pl-PL/modules.json
+++ b/localizations/pl-PL/modules.json
@@ -106,7 +106,6 @@
       "channels": "Kanały",
       "stableReleases": "Wydania stabilne",
       "betaReleases": "Wydania beta",
-      "devReleases": "Wydania developerskie",
       "invalidChanel": "Niepoprawny kanał"
     }
   },

--- a/localizations/pt-BR/modules.json
+++ b/localizations/pt-BR/modules.json
@@ -106,7 +106,6 @@
       "channels": "Canais",
       "stableReleases": "Releases Estáveis",
       "betaReleases": "Releases Beta",
-      "devReleases": "Releases Dev",
       "invalidChanel": "Canal inválido"
     }
   },

--- a/localizations/ru-RU/modules.json
+++ b/localizations/ru-RU/modules.json
@@ -106,7 +106,6 @@
       "channels": "Каналы",
       "stableReleases": "Стабильные релизы",
       "betaReleases": "Бета-релизы",
-      "devReleases": "Релизы разработчиков",
       "invalidChanel": "Некорректный канал"
     }
   },

--- a/localizations/sv-SE/modules.json
+++ b/localizations/sv-SE/modules.json
@@ -106,7 +106,6 @@
       "channels": "Kaneler",
       "stableReleases": "Stabil releaser",
       "betaReleases": "Beta releaser",
-      "devReleases": "Dev releaser",
       "invalidChanel": "Felaktig kanal"
     }
   },

--- a/localizations/tr-TR/modules.json
+++ b/localizations/tr-TR/modules.json
@@ -106,7 +106,6 @@
       "channels": "Kanallar",
       "stableReleases": "Stabil Yayınlar",
       "betaReleases": "Beta Yayınlar",
-      "devReleases": "Geliştirici Yayınlar",
       "invalidChanel": "Geçersiz kanal"
     }
   },

--- a/localizations/uk-UA/modules.json
+++ b/localizations/uk-UA/modules.json
@@ -106,7 +106,6 @@
       "channels": "Канали",
       "stableReleases": "Стабільні релізи",
       "betaReleases": "Бета-релізи",
-      "devReleases": "Релізи розробників",
       "invalidChanel": "Недійсний канал"
     }
   },

--- a/localizations/uz-CY/modules.json
+++ b/localizations/uz-CY/modules.json
@@ -106,7 +106,6 @@
       "channels": "Каналлар",
       "stableReleases": "Барқарор нашрлар",
       "betaReleases": "Бета нашрлар",
-      "devReleases": "Ишлаб чиқарувчи нашрлари",
       "invalidChanel": "Яроқсиз канал"
     }
   },

--- a/localizations/uz-LA/modules.json
+++ b/localizations/uz-LA/modules.json
@@ -106,7 +106,6 @@
       "channels": "Kanallar",
       "stableReleases": "Barqaror nashrlar",
       "betaReleases": "Beta nashrlar",
-      "devReleases": "Ishlab chiqaruvchi nashrlari",
       "invalidChanel": "Yaroqsiz kanal"
     }
   },

--- a/localizations/zh-CN/modules.json
+++ b/localizations/zh-CN/modules.json
@@ -106,7 +106,6 @@
       "channels": "渠道",
       "stableReleases": "Stable 发行版",
       "betaReleases": "Beta 发行版",
-      "devReleases": "Dev 发行版",
       "invalidChanel": "无效渠道"
     }
   },

--- a/localizations/zh-TW/modules.json
+++ b/localizations/zh-TW/modules.json
@@ -106,7 +106,6 @@
       "channels": "通道",
       "stableReleases": "Stable 發行版",
       "betaReleases": "Beta 發行版",
-      "devReleases": "Dev 發行版",
       "invalidChanel": "無效通道"
     }
   },


### PR DESCRIPTION
As the `dev` channel has been deprecated for the last two years or so, doesn't seem to make sense to show it anymore in releases page.

![Bildschirmfoto 2024-02-15 um 08 52 31](https://github.com/fluttertools/sidekick/assets/13286425/32f3f2f1-88ee-4d74-9456-a40ba79f9c60)
