### PR TITLE
feat(native): signle-window-instance

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -4,6 +4,19 @@ import FlutterMacOS
 @main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return false
+  }
+
+  override func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    if !flag {
+        for window in NSApp.windows {
+        if !window.isVisible {
+            window.setIsVisible(true)
+        }
+        window.makeKeyAndOrderFront(self)
+        NSApp.activate(ignoringOtherApps: true)
+        }
+    }
     return true
   }
 

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -10,6 +10,12 @@ auto bdw = bitsdojo_window_configure(BDW_CUSTOM_FRAME | BDW_HIDE_ON_STARTUP);
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command)
 {
+    HWND hwnd = ::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"Sidekick");
+    if (hwnd != NULL) {
+        ::ShowWindow(hwnd, SW_NORMAL);
+        ::SetForegroundWindow(hwnd);
+        return EXIT_FAILURE;
+    }
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent())


### PR DESCRIPTION
fix  
#318

note:  
applicationShouldTerminateAfterLastWindowClosed https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428381-applicationshouldterminateafterl
close window don't terminate app, if you should use close to terminate , maybe you can use https://pub.dev/packages/window_manager#quit-on-close